### PR TITLE
Add agenda page with weekly calendar view

### DIFF
--- a/kabelkrant-manager/src/app/App.tsx
+++ b/kabelkrant-manager/src/app/App.tsx
@@ -7,6 +7,7 @@ import { v4 } from 'uuid'
 import { Pages } from './consts/pages'
 import { Programs } from './page/Programs'
 import { Playlist } from './page/Playlist'
+import { Agenda } from './page/Agenda'
 
 function App() {
   const [programs, setPrograms] = useState<ProgrammaFormSchema[]>([])
@@ -92,6 +93,11 @@ function App() {
       text: "Speelt nu af",
       isSelected: page == Pages.CURRENT_PLAYLIST,
       onClick: () => setPage(Pages.CURRENT_PLAYLIST)
+    },{
+      type: SidebarItemTypes.BUTTON,
+      text: "Agenda",
+      isSelected: page == Pages.AGENDA,
+      onClick: () => setPage(Pages.AGENDA)
     }]
   }), [programs, selectedIndex, page ])
 
@@ -106,6 +112,7 @@ function App() {
         <div className='mt-5 flex-1 bg-white px-5 py-2 rounded-md'>
           {page == Pages.PROGRAMS && <Programs selectedItem={selectedItem} programs={programs} selectedIndex={selectedIndex} setPrograms={setPrograms} />}
           {page == Pages.CURRENT_PLAYLIST && <Playlist/>}
+          {page == Pages.AGENDA && <Agenda programs={programs}/>}
         </div>
       </div>
 

--- a/kabelkrant-manager/src/app/components/agenda/AgendaDayColumn.tsx
+++ b/kabelkrant-manager/src/app/components/agenda/AgendaDayColumn.tsx
@@ -1,0 +1,72 @@
+import { FC } from "react";
+import { ScheduledEvent, HOUR_HEIGHT, HOURS_IN_DAY } from "./types";
+import { AgendaEvent } from "./AgendaEvent";
+
+export interface AgendaDayColumnProps {
+    dayName: string;
+    date: Date;
+    isToday: boolean;
+    events: ScheduledEvent[];
+    programColorMap: Map<string, string>;
+}
+
+const hours = Array.from({ length: HOURS_IN_DAY }, (_, i) => i);
+
+const formatDate = (date: Date) => {
+    return date.toLocaleDateString("nl-NL", { day: "numeric", month: "short" });
+};
+
+export const AgendaDayColumn: FC<AgendaDayColumnProps> = ({
+    dayName,
+    date,
+    isToday,
+    events,
+    programColorMap,
+}) => {
+    // Group events by hour for rendering
+    const eventsByHour = new Map<number, ScheduledEvent[]>();
+    hours.forEach((hour) => eventsByHour.set(hour, []));
+
+    events.forEach((event) => {
+        const hourEvents = eventsByHour.get(event.hour);
+        if (hourEvents) {
+            hourEvents.push(event);
+        }
+    });
+
+    const headerClass = isToday ? "bg-blue-50 text-blue-600" : "bg-gray-50";
+    const columnClass = isToday ? "bg-blue-50/30" : "";
+
+    return (
+        <div className="flex-1 min-w-[120px] border-r">
+            {/* Day header */}
+            <div className={`p-2 border-b text-center sticky top-0 z-10 ${headerClass}`}>
+                <div className="font-medium text-sm">{dayName}</div>
+                <div className="text-xs text-gray-500">{formatDate(date)}</div>
+            </div>
+
+            {/* Hour slots */}
+            <div className={columnClass}>
+                {hours.map((hour) => {
+                    const hourEvents = eventsByHour.get(hour) || [];
+
+                    return (
+                        <div
+                            key={hour}
+                            className="border-b relative"
+                            style={{ height: `${HOUR_HEIGHT}px` }}
+                        >
+                            {hourEvents.map((event, index) => (
+                                <AgendaEvent
+                                    key={`${event.program.id}-${event.time}-${index}`}
+                                    event={event}
+                                    color={programColorMap.get(event.program.id) || "bg-gray-500"}
+                                />
+                            ))}
+                        </div>
+                    );
+                })}
+            </div>
+        </div>
+    );
+};

--- a/kabelkrant-manager/src/app/components/agenda/AgendaEvent.tsx
+++ b/kabelkrant-manager/src/app/components/agenda/AgendaEvent.tsx
@@ -1,0 +1,58 @@
+import { FC } from "react";
+import { ScheduledEvent, HOUR_HEIGHT } from "./types";
+
+export interface AgendaEventProps {
+    event: ScheduledEvent;
+    color: string;
+}
+
+export const AgendaEvent: FC<AgendaEventProps> = ({ event, color }) => {
+    // Calculate position within the hour (in pixels)
+    const minuteOffset = (event.minute / 60) * HOUR_HEIGHT;
+
+    // Calculate height based on duration (minimum 20px for visibility)
+    const durationMinutes = event.durationSeconds / 60;
+    const height = Math.max((durationMinutes / 60) * HOUR_HEIGHT, 20);
+
+    // Format start time (HH:MM)
+    const startTime = event.time.substring(0, 5);
+
+    // Format end time (HH:MM)
+    const endTime = event.endTime.substring(0, 5);
+
+    // Format duration for display
+    const formatDuration = (seconds: number) => {
+        const hours = Math.floor(seconds / 3600);
+        const mins = Math.floor((seconds % 3600) / 60);
+        if (hours > 0) {
+            return `${hours}u ${mins}m`;
+        }
+        return `${mins}m`;
+    };
+
+    return (
+        <div
+            className={`${color} text-white text-xs p-1 rounded absolute left-0 right-0 mx-1 overflow-hidden cursor-default shadow-sm border border-white/20`}
+            style={{
+                top: `${minuteOffset}px`,
+                height: `${height}px`,
+                minHeight: "20px",
+            }}
+            title={`${event.program.programName}\n${startTime} - ${endTime}\nDuur: ${formatDuration(event.durationSeconds)}`}
+        >
+            <div className="font-medium truncate">
+                {event.program.programName}
+            </div>
+            {height >= 35 && (
+                <div className="opacity-80 truncate">
+                    {startTime} - {endTime}
+                </div>
+            )}
+            {height >= 50 && (
+                <div className="opacity-70 text-[10px] truncate">
+                    {formatDuration(event.durationSeconds)}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/kabelkrant-manager/src/app/components/agenda/AgendaGrid.tsx
+++ b/kabelkrant-manager/src/app/components/agenda/AgendaGrid.tsx
@@ -1,0 +1,48 @@
+import { FC } from "react";
+import { days } from "../../type/days";
+import { ScheduledEvent } from "./types";
+import { AgendaTimeColumn } from "./AgendaTimeColumn";
+import { AgendaDayColumn } from "./AgendaDayColumn";
+
+export interface AgendaGridProps {
+    weekDates: Date[];
+    scheduleByDay: Map<number, ScheduledEvent[]>;
+    programColorMap: Map<string, string>;
+}
+
+const isToday = (date: Date) => {
+    const today = new Date();
+    return date.toDateString() === today.toDateString();
+};
+
+export const AgendaGrid: FC<AgendaGridProps> = ({
+    weekDates,
+    scheduleByDay,
+    programColorMap,
+}) => {
+    return (
+        <div className="flex-1 overflow-auto border rounded-lg">
+            <div className="flex min-w-[900px]">
+                {/* Time column */}
+                <AgendaTimeColumn />
+
+                {/* Day columns */}
+                {days.map((day, index) => {
+                    const date = weekDates[index];
+                    const events = scheduleByDay.get(day.value) || [];
+
+                    return (
+                        <AgendaDayColumn
+                            key={day.value}
+                            dayName={day.name}
+                            date={date}
+                            isToday={isToday(date)}
+                            events={events}
+                            programColorMap={programColorMap}
+                        />
+                    );
+                })}
+            </div>
+        </div>
+    );
+};

--- a/kabelkrant-manager/src/app/components/agenda/AgendaHeader.tsx
+++ b/kabelkrant-manager/src/app/components/agenda/AgendaHeader.tsx
@@ -1,0 +1,34 @@
+import { FC } from "react";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+export interface AgendaHeaderProps {
+    weekOffset: number;
+    onPreviousWeek: () => void;
+    onNextWeek: () => void;
+    onToday: () => void;
+}
+
+export const AgendaHeader: FC<AgendaHeaderProps> = ({
+    weekOffset,
+    onPreviousWeek,
+    onNextWeek,
+    onToday,
+}) => {
+    return (
+        <div className="flex items-center justify-between">
+            <h3 className="text-xl font-semibold">Agenda</h3>
+            <div className="flex items-center gap-2">
+                <Button variant="outline" size="sm" onClick={onPreviousWeek}>
+                    <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <Button variant="outline" size="sm" onClick={onToday}>
+                    Vandaag
+                </Button>
+                <Button variant="outline" size="sm" onClick={onNextWeek}>
+                    <ChevronRight className="h-4 w-4" />
+                </Button>
+            </div>
+        </div>
+    );
+};

--- a/kabelkrant-manager/src/app/components/agenda/AgendaLegend.tsx
+++ b/kabelkrant-manager/src/app/components/agenda/AgendaLegend.tsx
@@ -1,0 +1,29 @@
+import { FC } from "react";
+import { ProgrammaFormSchema } from "../../type/programFormName";
+
+export interface AgendaLegendProps {
+    programs: ProgrammaFormSchema[];
+    programColorMap: Map<string, string>;
+}
+
+export const AgendaLegend: FC<AgendaLegendProps> = ({
+    programs,
+    programColorMap,
+}) => {
+    if (programs.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="flex flex-wrap gap-2">
+            {programs.map((program) => (
+                <div key={program.id} className="flex items-center gap-1">
+                    <div
+                        className={`w-3 h-3 rounded ${programColorMap.get(program.id)}`}
+                    />
+                    <span className="text-xs">{program.programName}</span>
+                </div>
+            ))}
+        </div>
+    );
+};

--- a/kabelkrant-manager/src/app/components/agenda/AgendaTimeColumn.tsx
+++ b/kabelkrant-manager/src/app/components/agenda/AgendaTimeColumn.tsx
@@ -1,0 +1,26 @@
+import { FC } from "react";
+import { HOUR_HEIGHT, HOURS_IN_DAY } from "./types";
+
+export interface AgendaTimeColumnProps {}
+
+const hours = Array.from({ length: HOURS_IN_DAY }, (_, i) => i);
+
+const formatHour = (hour: number) => {
+    return `${hour.toString().padStart(2, "0")}:00`;
+};
+
+export const AgendaTimeColumn: FC<AgendaTimeColumnProps> = () => {
+    return (
+        <div className="flex-shrink-0 w-16 border-r bg-gray-50">
+            {hours.map((hour) => (
+                <div
+                    key={hour}
+                    className="border-b text-xs text-gray-500 text-right pr-2 flex items-start justify-end pt-1"
+                    style={{ height: `${HOUR_HEIGHT}px` }}
+                >
+                    {formatHour(hour)}
+                </div>
+            ))}
+        </div>
+    );
+};

--- a/kabelkrant-manager/src/app/components/agenda/index.ts
+++ b/kabelkrant-manager/src/app/components/agenda/index.ts
@@ -1,0 +1,7 @@
+export { AgendaHeader } from "./AgendaHeader";
+export { AgendaLegend } from "./AgendaLegend";
+export { AgendaEvent } from "./AgendaEvent";
+export { AgendaTimeColumn } from "./AgendaTimeColumn";
+export { AgendaDayColumn } from "./AgendaDayColumn";
+export { AgendaGrid } from "./AgendaGrid";
+export * from "./types";

--- a/kabelkrant-manager/src/app/components/agenda/types.ts
+++ b/kabelkrant-manager/src/app/components/agenda/types.ts
@@ -1,0 +1,36 @@
+import { ProgrammaFormSchema } from "../../type/programFormName";
+
+export interface ScheduledEvent {
+    program: ProgrammaFormSchema;
+    time: string;
+    hour: number;
+    minute: number;
+    second: number;
+    durationSeconds: number;
+    endTime: string;
+}
+
+export interface ProgramDuration {
+    programId: string;
+    totalDurationSeconds: number;
+}
+
+// Color palette for different programs
+export const PROGRAM_COLORS = [
+    "bg-blue-500",
+    "bg-green-500",
+    "bg-purple-500",
+    "bg-orange-500",
+    "bg-pink-500",
+    "bg-teal-500",
+    "bg-indigo-500",
+    "bg-red-500",
+    "bg-yellow-500",
+    "bg-cyan-500",
+];
+
+// Height of one hour in pixels
+export const HOUR_HEIGHT = 60;
+
+// Total hours in a day
+export const HOURS_IN_DAY = 24;

--- a/kabelkrant-manager/src/app/consts/pages.ts
+++ b/kabelkrant-manager/src/app/consts/pages.ts
@@ -1,4 +1,5 @@
 export enum Pages {
     PROGRAMS,
     CURRENT_PLAYLIST,
+    AGENDA,
 }

--- a/kabelkrant-manager/src/app/page/Agenda.tsx
+++ b/kabelkrant-manager/src/app/page/Agenda.tsx
@@ -1,0 +1,229 @@
+import { FC, useMemo, useState } from "react";
+import { ProgrammaFormSchema } from "../type/programFormName";
+import { days } from "../type/days";
+import { Button } from "@/components/ui/button";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+export interface AgendaProps {
+    programs: ProgrammaFormSchema[];
+}
+
+interface ScheduledEvent {
+    program: ProgrammaFormSchema;
+    time: string;
+    hour: number;
+    minute: number;
+}
+
+// Generate time slots for each hour from 0 to 23
+const hours = Array.from({ length: 24 }, (_, i) => i);
+
+// Color palette for different programs
+const programColors = [
+    "bg-blue-500",
+    "bg-green-500",
+    "bg-purple-500",
+    "bg-orange-500",
+    "bg-pink-500",
+    "bg-teal-500",
+    "bg-indigo-500",
+    "bg-red-500",
+    "bg-yellow-500",
+    "bg-cyan-500",
+];
+
+export const Agenda: FC<AgendaProps> = ({ programs }) => {
+    const [weekOffset, setWeekOffset] = useState(0);
+
+    // Get the current week's dates based on offset
+    const weekDates = useMemo(() => {
+        const today = new Date();
+        const currentDay = today.getDay(); // 0 = Sunday, 1 = Monday, etc.
+
+        const weekDates: Date[] = [];
+        for (let i = 0; i < 7; i++) {
+            const date = new Date(today);
+            date.setDate(today.getDate() - currentDay + i + (weekOffset * 7));
+            weekDates.push(date);
+        }
+        return weekDates;
+    }, [weekOffset]);
+
+    // Create a map of program id to color
+    const programColorMap = useMemo(() => {
+        const map = new Map<string, string>();
+        programs.forEach((program, index) => {
+            map.set(program.id, programColors[index % programColors.length]);
+        });
+        return map;
+    }, [programs]);
+
+    // Build schedule data: for each day, for each time slot
+    const scheduleByDayAndHour = useMemo(() => {
+        // Map: day (0-6) -> hour (0-23) -> events
+        const schedule: Map<number, Map<number, ScheduledEvent[]>> = new Map();
+
+        // Initialize empty schedule
+        for (let day = 0; day < 7; day++) {
+            schedule.set(day, new Map());
+            for (let hour = 0; hour < 24; hour++) {
+                schedule.get(day)!.set(hour, []);
+            }
+        }
+
+        // Fill in scheduled events
+        programs.forEach((program) => {
+            program.planning.forEach((planning) => {
+                planning.days.forEach((day) => {
+                    planning.times.forEach((time) => {
+                        const [hourStr, minuteStr] = time.split(":");
+                        const hour = parseInt(hourStr, 10);
+                        const minute = parseInt(minuteStr, 10);
+
+                        if (!isNaN(hour) && hour >= 0 && hour < 24) {
+                            schedule.get(day)!.get(hour)!.push({
+                                program,
+                                time,
+                                hour,
+                                minute,
+                            });
+                        }
+                    });
+                });
+            });
+        });
+
+        // Sort events within each hour by time
+        schedule.forEach((hourMap) => {
+            hourMap.forEach((events) => {
+                events.sort((a, b) => {
+                    if (a.hour !== b.hour) return a.hour - b.hour;
+                    return a.minute - b.minute;
+                });
+            });
+        });
+
+        return schedule;
+    }, [programs]);
+
+    const formatDate = (date: Date) => {
+        return date.toLocaleDateString("nl-NL", { day: "numeric", month: "short" });
+    };
+
+    const isToday = (date: Date) => {
+        const today = new Date();
+        return date.toDateString() === today.toDateString();
+    };
+
+    const formatHour = (hour: number) => {
+        return `${hour.toString().padStart(2, "0")}:00`;
+    };
+
+    return (
+        <div className="flex flex-col gap-4 h-full">
+            <div className="flex items-center justify-between">
+                <h3 className="text-xl font-semibold">Agenda</h3>
+                <div className="flex items-center gap-2">
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setWeekOffset(weekOffset - 1)}
+                    >
+                        <ChevronLeft className="h-4 w-4" />
+                    </Button>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setWeekOffset(0)}
+                    >
+                        Vandaag
+                    </Button>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => setWeekOffset(weekOffset + 1)}
+                    >
+                        <ChevronRight className="h-4 w-4" />
+                    </Button>
+                </div>
+            </div>
+
+            {/* Legend */}
+            <div className="flex flex-wrap gap-2">
+                {programs.map((program) => (
+                    <div key={program.id} className="flex items-center gap-1">
+                        <div
+                            className={`w-3 h-3 rounded ${programColorMap.get(program.id)}`}
+                        />
+                        <span className="text-xs">{program.programName}</span>
+                    </div>
+                ))}
+            </div>
+
+            {/* Calendar Grid */}
+            <div className="flex-1 overflow-auto border rounded-lg">
+                <div className="min-w-[800px]">
+                    {/* Header with days */}
+                    <div className="grid grid-cols-8 border-b sticky top-0 bg-white z-10">
+                        <div className="p-2 border-r text-center text-sm font-medium text-gray-500">
+                            Tijd
+                        </div>
+                        {days.map((day, index) => {
+                            const date = weekDates[index];
+                            const todayClass = isToday(date)
+                                ? "bg-blue-50 text-blue-600"
+                                : "";
+                            return (
+                                <div
+                                    key={day.value}
+                                    className={`p-2 border-r text-center ${todayClass}`}
+                                >
+                                    <div className="font-medium text-sm">{day.name}</div>
+                                    <div className="text-xs text-gray-500">
+                                        {formatDate(date)}
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+
+                    {/* Time slots */}
+                    {hours.map((hour) => (
+                        <div key={hour} className="grid grid-cols-8 border-b min-h-[60px]">
+                            <div className="p-1 border-r text-xs text-gray-500 text-center">
+                                {formatHour(hour)}
+                            </div>
+                            {days.map((day) => {
+                                const events = scheduleByDayAndHour.get(day.value)?.get(hour) || [];
+                                const date = weekDates[day.value];
+                                const todayClass = isToday(date) ? "bg-blue-50/50" : "";
+
+                                return (
+                                    <div
+                                        key={`${day.value}-${hour}`}
+                                        className={`p-1 border-r relative ${todayClass}`}
+                                    >
+                                        {events.map((event, eventIndex) => (
+                                            <div
+                                                key={`${event.program.id}-${event.time}-${eventIndex}`}
+                                                className={`${programColorMap.get(event.program.id)} text-white text-xs p-1 rounded mb-1 truncate cursor-default`}
+                                                title={`${event.program.programName} - ${event.time}`}
+                                            >
+                                                <div className="font-medium truncate">
+                                                    {event.program.programName}
+                                                </div>
+                                                <div className="opacity-80">
+                                                    {event.time.substring(0, 5)}
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/kabelkrant-manager/src/app/page/Agenda.tsx
+++ b/kabelkrant-manager/src/app/page/Agenda.tsx
@@ -1,91 +1,136 @@
-import { FC, useMemo, useState } from "react";
+import { FC, useCallback, useEffect, useMemo, useState } from "react";
 import { ProgrammaFormSchema } from "../type/programFormName";
-import { days } from "../type/days";
-import { Button } from "@/components/ui/button";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { VideoFile } from "../../global/types/FileMetaTypes";
+import {
+    AgendaHeader,
+    AgendaLegend,
+    AgendaGrid,
+    ScheduledEvent,
+    PROGRAM_COLORS,
+} from "../components/agenda";
 
 export interface AgendaProps {
     programs: ProgrammaFormSchema[];
 }
 
-interface ScheduledEvent {
-    program: ProgrammaFormSchema;
-    time: string;
-    hour: number;
-    minute: number;
-}
-
-// Generate time slots for each hour from 0 to 23
-const hours = Array.from({ length: 24 }, (_, i) => i);
-
-// Color palette for different programs
-const programColors = [
-    "bg-blue-500",
-    "bg-green-500",
-    "bg-purple-500",
-    "bg-orange-500",
-    "bg-pink-500",
-    "bg-teal-500",
-    "bg-indigo-500",
-    "bg-red-500",
-    "bg-yellow-500",
-    "bg-cyan-500",
-];
-
 export const Agenda: FC<AgendaProps> = ({ programs }) => {
     const [weekOffset, setWeekOffset] = useState(0);
+    const [programDurations, setProgramDurations] = useState<Map<string, number>>(new Map());
+    const [isLoading, setIsLoading] = useState(true);
+
+    // Fetch video durations for all programs
+    const fetchDurations = useCallback(async () => {
+        setIsLoading(true);
+        const durations = new Map<string, number>();
+
+        await Promise.all(
+            programs.map(async (program) => {
+                if (!program.path) {
+                    durations.set(program.id, 0);
+                    return;
+                }
+
+                try {
+                    const files = await window.electronApi.getFilesInFolder(program.path);
+                    const videoFiles = files.filter((f): f is VideoFile => f.type === "video");
+
+                    // Calculate total duration based on playAll setting
+                    let totalDuration = 0;
+                    if (program.playAll) {
+                        // Sum all video durations
+                        totalDuration = videoFiles.reduce((sum, file) => sum + (file.duration || 0), 0);
+                    } else {
+                        // Use average video duration (since it picks one)
+                        const avgDuration = videoFiles.length > 0
+                            ? videoFiles.reduce((sum, file) => sum + (file.duration || 0), 0) / videoFiles.length
+                            : 0;
+                        totalDuration = avgDuration;
+                    }
+
+                    durations.set(program.id, totalDuration);
+                } catch (error) {
+                    console.error(`Error fetching duration for ${program.programName}:`, error);
+                    durations.set(program.id, 0);
+                }
+            })
+        );
+
+        setProgramDurations(durations);
+        setIsLoading(false);
+    }, [programs]);
+
+    useEffect(() => {
+        fetchDurations();
+    }, [fetchDurations]);
 
     // Get the current week's dates based on offset
     const weekDates = useMemo(() => {
         const today = new Date();
         const currentDay = today.getDay(); // 0 = Sunday, 1 = Monday, etc.
 
-        const weekDates: Date[] = [];
+        const dates: Date[] = [];
         for (let i = 0; i < 7; i++) {
             const date = new Date(today);
-            date.setDate(today.getDate() - currentDay + i + (weekOffset * 7));
-            weekDates.push(date);
+            date.setDate(today.getDate() - currentDay + i + weekOffset * 7);
+            dates.push(date);
         }
-        return weekDates;
+        return dates;
     }, [weekOffset]);
 
     // Create a map of program id to color
     const programColorMap = useMemo(() => {
         const map = new Map<string, string>();
         programs.forEach((program, index) => {
-            map.set(program.id, programColors[index % programColors.length]);
+            map.set(program.id, PROGRAM_COLORS[index % PROGRAM_COLORS.length]);
         });
         return map;
     }, [programs]);
 
-    // Build schedule data: for each day, for each time slot
-    const scheduleByDayAndHour = useMemo(() => {
-        // Map: day (0-6) -> hour (0-23) -> events
-        const schedule: Map<number, Map<number, ScheduledEvent[]>> = new Map();
+    // Calculate end time given start time and duration
+    const calculateEndTime = (startTime: string, durationSeconds: number): string => {
+        const [hours, minutes, seconds] = startTime.split(":").map(Number);
+        const startSeconds = hours * 3600 + minutes * 60 + (seconds || 0);
+        const endSeconds = startSeconds + durationSeconds;
 
-        // Initialize empty schedule
+        const endHours = Math.floor(endSeconds / 3600) % 24;
+        const endMinutes = Math.floor((endSeconds % 3600) / 60);
+        const endSecs = Math.floor(endSeconds % 60);
+
+        return `${endHours.toString().padStart(2, "0")}:${endMinutes.toString().padStart(2, "0")}:${endSecs.toString().padStart(2, "0")}`;
+    };
+
+    // Build schedule data: for each day, list of events
+    const scheduleByDay = useMemo(() => {
+        const schedule = new Map<number, ScheduledEvent[]>();
+
+        // Initialize empty schedule for each day
         for (let day = 0; day < 7; day++) {
-            schedule.set(day, new Map());
-            for (let hour = 0; hour < 24; hour++) {
-                schedule.get(day)!.set(hour, []);
-            }
+            schedule.set(day, []);
         }
 
         // Fill in scheduled events
         programs.forEach((program) => {
+            const duration = programDurations.get(program.id) || 0;
+
             program.planning.forEach((planning) => {
                 planning.days.forEach((day) => {
                     planning.times.forEach((time) => {
-                        const [hourStr, minuteStr] = time.split(":");
+                        const [hourStr, minuteStr, secondStr] = time.split(":");
                         const hour = parseInt(hourStr, 10);
                         const minute = parseInt(minuteStr, 10);
+                        const second = parseInt(secondStr || "0", 10);
 
                         if (!isNaN(hour) && hour >= 0 && hour < 24) {
-                            schedule.get(day)!.get(hour)!.push({
+                            const endTime = calculateEndTime(time, duration);
+
+                            schedule.get(day)!.push({
                                 program,
                                 time,
                                 hour,
                                 minute,
+                                second,
+                                durationSeconds: duration,
+                                endTime,
                             });
                         }
                     });
@@ -93,137 +138,44 @@ export const Agenda: FC<AgendaProps> = ({ programs }) => {
             });
         });
 
-        // Sort events within each hour by time
-        schedule.forEach((hourMap) => {
-            hourMap.forEach((events) => {
-                events.sort((a, b) => {
-                    if (a.hour !== b.hour) return a.hour - b.hour;
-                    return a.minute - b.minute;
-                });
+        // Sort events within each day by time
+        schedule.forEach((events) => {
+            events.sort((a, b) => {
+                if (a.hour !== b.hour) return a.hour - b.hour;
+                if (a.minute !== b.minute) return a.minute - b.minute;
+                return a.second - b.second;
             });
         });
 
         return schedule;
-    }, [programs]);
+    }, [programs, programDurations]);
 
-    const formatDate = (date: Date) => {
-        return date.toLocaleDateString("nl-NL", { day: "numeric", month: "short" });
-    };
-
-    const isToday = (date: Date) => {
-        const today = new Date();
-        return date.toDateString() === today.toDateString();
-    };
-
-    const formatHour = (hour: number) => {
-        return `${hour.toString().padStart(2, "0")}:00`;
-    };
+    const handlePreviousWeek = () => setWeekOffset(weekOffset - 1);
+    const handleNextWeek = () => setWeekOffset(weekOffset + 1);
+    const handleToday = () => setWeekOffset(0);
 
     return (
         <div className="flex flex-col gap-4 h-full">
-            <div className="flex items-center justify-between">
-                <h3 className="text-xl font-semibold">Agenda</h3>
-                <div className="flex items-center gap-2">
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setWeekOffset(weekOffset - 1)}
-                    >
-                        <ChevronLeft className="h-4 w-4" />
-                    </Button>
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setWeekOffset(0)}
-                    >
-                        Vandaag
-                    </Button>
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => setWeekOffset(weekOffset + 1)}
-                    >
-                        <ChevronRight className="h-4 w-4" />
-                    </Button>
+            <AgendaHeader
+                weekOffset={weekOffset}
+                onPreviousWeek={handlePreviousWeek}
+                onNextWeek={handleNextWeek}
+                onToday={handleToday}
+            />
+
+            <AgendaLegend programs={programs} programColorMap={programColorMap} />
+
+            {isLoading ? (
+                <div className="flex-1 flex items-center justify-center text-gray-500">
+                    Laden...
                 </div>
-            </div>
-
-            {/* Legend */}
-            <div className="flex flex-wrap gap-2">
-                {programs.map((program) => (
-                    <div key={program.id} className="flex items-center gap-1">
-                        <div
-                            className={`w-3 h-3 rounded ${programColorMap.get(program.id)}`}
-                        />
-                        <span className="text-xs">{program.programName}</span>
-                    </div>
-                ))}
-            </div>
-
-            {/* Calendar Grid */}
-            <div className="flex-1 overflow-auto border rounded-lg">
-                <div className="min-w-[800px]">
-                    {/* Header with days */}
-                    <div className="grid grid-cols-8 border-b sticky top-0 bg-white z-10">
-                        <div className="p-2 border-r text-center text-sm font-medium text-gray-500">
-                            Tijd
-                        </div>
-                        {days.map((day, index) => {
-                            const date = weekDates[index];
-                            const todayClass = isToday(date)
-                                ? "bg-blue-50 text-blue-600"
-                                : "";
-                            return (
-                                <div
-                                    key={day.value}
-                                    className={`p-2 border-r text-center ${todayClass}`}
-                                >
-                                    <div className="font-medium text-sm">{day.name}</div>
-                                    <div className="text-xs text-gray-500">
-                                        {formatDate(date)}
-                                    </div>
-                                </div>
-                            );
-                        })}
-                    </div>
-
-                    {/* Time slots */}
-                    {hours.map((hour) => (
-                        <div key={hour} className="grid grid-cols-8 border-b min-h-[60px]">
-                            <div className="p-1 border-r text-xs text-gray-500 text-center">
-                                {formatHour(hour)}
-                            </div>
-                            {days.map((day) => {
-                                const events = scheduleByDayAndHour.get(day.value)?.get(hour) || [];
-                                const date = weekDates[day.value];
-                                const todayClass = isToday(date) ? "bg-blue-50/50" : "";
-
-                                return (
-                                    <div
-                                        key={`${day.value}-${hour}`}
-                                        className={`p-1 border-r relative ${todayClass}`}
-                                    >
-                                        {events.map((event, eventIndex) => (
-                                            <div
-                                                key={`${event.program.id}-${event.time}-${eventIndex}`}
-                                                className={`${programColorMap.get(event.program.id)} text-white text-xs p-1 rounded mb-1 truncate cursor-default`}
-                                                title={`${event.program.programName} - ${event.time}`}
-                                            >
-                                                <div className="font-medium truncate">
-                                                    {event.program.programName}
-                                                </div>
-                                                <div className="opacity-80">
-                                                    {event.time.substring(0, 5)}
-                                                </div>
-                                            </div>
-                                        ))}
-                                    </div>
-                                );
-                            })}
-                        </div>
-                    ))}
-                </div>
-            </div>
+            ) : (
+                <AgendaGrid
+                    weekDates={weekDates}
+                    scheduleByDay={scheduleByDay}
+                    programColorMap={programColorMap}
+                />
+            )}
         </div>
     );
 };


### PR DESCRIPTION
Add a Google Calendar-like agenda page that displays all scheduled programs
in a weekly grid view with:
- Week navigation (previous/next week, today button)
- Color-coded programs with legend
- 24-hour time slots showing scheduled events
- Today highlighting
- Dutch localization for dates and day names